### PR TITLE
Revert "Chore:Limiting routing matches in Routes.rb for sites"

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
-  resources :sites, , only: [:index, :show, :create, :update, :destroy]
-  resources :events, only: [:index, :show, :create, :update, :destroy]
+  resources :places
+
+ resources :events, only: [:index, :show, :create, :update, :destroy, :delete]
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 	root 'events#index'
 	get '/:id' => "events#show"


### PR DESCRIPTION
Reverts MapLendar/ms_events_and_places#3

Verify affected controllers, routes won't match